### PR TITLE
Re-implement `notifyamqp.listener` completely as a state-machine.

### DIFF
--- a/src/rinq/internal/service/error.go
+++ b/src/rinq/internal/service/error.go
@@ -1,0 +1,7 @@
+package service
+
+import "errors"
+
+// ErrStopped is returned by any operation that can not be fulfilled because
+// the service that provides it is stopping or has already stopped.
+var ErrStopped = errors.New("service has been stopped")


### PR DESCRIPTION
This partially addresses #139. The `server` code has not been fixed yet.