### PR TITLE
Add the message ID of notifications and command requests to their respective structs.

### DIFF
--- a/src/rinq/amqp/internal/commandamqp/response.go
+++ b/src/rinq/amqp/internal/commandamqp/response.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/rinq/rinq-go/src/rinq"
 	"github.com/rinq/rinq-go/src/rinq/amqp/internal/amqputil"
-	"github.com/rinq/rinq-go/src/rinq/ident"
 	"github.com/streadway/amqp"
 )
 
@@ -16,7 +15,6 @@ import (
 type response struct {
 	context  context.Context
 	channels amqputil.ChannelPool
-	msgID    ident.MessageID
 	request  rinq.Request
 
 	mutex     sync.RWMutex
@@ -27,14 +25,12 @@ type response struct {
 func newResponse(
 	ctx context.Context,
 	channels amqputil.ChannelPool,
-	msgID ident.MessageID,
 	request rinq.Request,
 	replyMode replyMode,
 ) (rinq.Response, func() bool) {
 	r := &response{
 		context:   ctx,
 		channels:  channels,
-		msgID:     msgID,
 		request:   request,
 		replyMode: replyMode,
 	}
@@ -166,7 +162,7 @@ func (r *response) respond(msg *amqp.Publishing) {
 
 	err = channel.Publish(
 		responseExchange,
-		r.msgID.String(),
+		r.request.ID.String(),
 		false, // mandatory,
 		false, // immediate,
 		*msg,

--- a/src/rinq/amqp/peer.go
+++ b/src/rinq/amqp/peer.go
@@ -114,7 +114,6 @@ func (p *peer) Listen(namespace string, handler rinq.CommandHandler) error {
 		namespace,
 		func(
 			ctx context.Context,
-			msgID ident.MessageID,
 			req rinq.Request,
 			res rinq.Response,
 		) {
@@ -122,7 +121,7 @@ func (p *peer) Listen(namespace string, handler rinq.CommandHandler) error {
 
 			traceutil.SetupCommand(
 				span,
-				msgID,
+				req.ID,
 				req.Namespace,
 				req.Command,
 			)

--- a/src/rinq/command.go
+++ b/src/rinq/command.go
@@ -3,6 +3,8 @@ package rinq
 import (
 	"context"
 	"fmt"
+
+	"github.com/rinq/rinq-go/src/rinq/ident"
 )
 
 // CommandHandler is a callback-function invoked when a command request is
@@ -25,6 +27,9 @@ type CommandHandler func(
 
 // Request holds information about an incoming command request.
 type Request struct {
+	// ID uniquely identifies the command request.
+	ID ident.MessageID
+
 	// Source is the revision of the session that sent the request, at the time
 	// it was sent (which is not necessarily the latest).
 	Source Revision

--- a/src/rinq/internal/command/server.go
+++ b/src/rinq/internal/command/server.go
@@ -1,26 +1,14 @@
 package command
 
 import (
-	"context"
-
 	"github.com/rinq/rinq-go/src/rinq"
-	"github.com/rinq/rinq-go/src/rinq/ident"
 	"github.com/rinq/rinq-go/src/rinq/internal/service"
-)
-
-// Handler is a callback-function invoked when a command request is
-// received by the peer.
-type Handler func(
-	ctx context.Context,
-	msgID ident.MessageID,
-	req rinq.Request,
-	res rinq.Response,
 )
 
 // Server processes command requests made by an invoker.
 type Server interface {
 	service.Service
 
-	Listen(namespace string, handler Handler) (bool, error)
-	Unlisten(namespace string) (bool, error)
+	Listen(ns string, h rinq.CommandHandler) (bool, error)
+	Unlisten(ns string) (bool, error)
 }

--- a/src/rinq/internal/localsession/session.go
+++ b/src/rinq/internal/localsession/session.go
@@ -342,7 +342,6 @@ func (s *session) Listen(ns string, handler rinq.NotificationHandler) error {
 		ns,
 		func(
 			ctx context.Context,
-			msgID ident.MessageID,
 			target rinq.Session,
 			n rinq.Notification,
 		) {
@@ -350,7 +349,7 @@ func (s *session) Listen(ns string, handler rinq.NotificationHandler) error {
 			ref := rev.Ref()
 
 			span := opentracing.SpanFromContext(ctx)
-			traceutil.SetupNotification(span, msgID, n.Namespace, n.Type)
+			traceutil.SetupNotification(span, n.ID, n.Namespace, n.Type)
 			traceutil.LogListenerReceived(span, ref, n)
 
 			// TODO: move to function

--- a/src/rinq/internal/notify/listener.go
+++ b/src/rinq/internal/notify/listener.go
@@ -1,27 +1,16 @@
 package notify
 
 import (
-	"context"
-
 	"github.com/rinq/rinq-go/src/rinq"
 	"github.com/rinq/rinq-go/src/rinq/ident"
 	"github.com/rinq/rinq-go/src/rinq/internal/service"
-)
-
-// Handler is a callback-function invoked when a inter-session
-// notification is received.
-type Handler func(
-	ctx context.Context,
-	msgID ident.MessageID,
-	target rinq.Session,
-	n rinq.Notification,
 )
 
 // Listener accepts notifications sent by a notifier.
 type Listener interface {
 	service.Service
 
-	Listen(id ident.SessionID, ns string, h Handler) (bool, error)
+	Listen(id ident.SessionID, ns string, h rinq.NotificationHandler) (bool, error)
 	Unlisten(id ident.SessionID, ns string) (bool, error)
 	UnlistenAll(id ident.SessionID) error
 }

--- a/src/rinq/internal/remotesession/server.go
+++ b/src/rinq/internal/remotesession/server.go
@@ -38,7 +38,6 @@ func Listen(
 
 func (s *server) handle(
 	ctx context.Context,
-	_ ident.MessageID,
 	req rinq.Request,
 	res rinq.Response,
 ) {

--- a/src/rinq/notification.go
+++ b/src/rinq/notification.go
@@ -4,10 +4,14 @@ import (
 	"context"
 
 	"github.com/rinq/rinq-go/src/rinq/constraint"
+	"github.com/rinq/rinq-go/src/rinq/ident"
 )
 
 // Notification holds information about an inter-session notification.
 type Notification struct {
+	// ID uniquely identifies the notification.
+	ID ident.MessageID
+
 	// Source refers to the session that sent the notification.
 	Source Revision
 


### PR DESCRIPTION
Fixes #144

This simplifies several cases where the message ID had to be passed around along with
the struct.

There is precedent for exposing the message ID to the user, both via the logs and the
return value of `Session.CallAsync()`.