### PR TITLE
Make `Session.Destroy()` a non-blocking operation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next Release
+
+- **[BC]** `Session.Destroy()` no longer waits for pending calls, use `Session.Done()` to wait
+
 ## 0.6.0 (2017-10-27)
 
 - **[BC]** Rename the `amqp` package to `rinqamqp`

--- a/src/internal/remotesession/revision_functional_test.go
+++ b/src/internal/remotesession/revision_functional_test.go
@@ -66,6 +66,7 @@ var _ = Describe("revision (functional)", func() {
 
 		It("returns a not found error if the session has been destroyed", func() {
 			session.Destroy()
+			<-session.Done()
 
 			_, err := remote.Refresh(ctx)
 			Expect(err).To(HaveOccurred())
@@ -82,6 +83,7 @@ var _ = Describe("revision (functional)", func() {
 
 		It("returns an empty attribute at revision zero after the session is destroyed", func() {
 			session.Destroy()
+			<-session.Done()
 
 			attr, err := remote.Get(ctx, ns, "a")
 			Expect(err).NotTo(HaveOccurred())
@@ -169,6 +171,7 @@ var _ = Describe("revision (functional)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			session.Destroy()
+			<-session.Done()
 
 			_, err = remote.Get(ctx, ns, "a")
 			Expect(err).To(HaveOccurred())
@@ -190,6 +193,7 @@ var _ = Describe("revision (functional)", func() {
 
 		It("returns empty attributes at revision zero after the session is destroyed", func() {
 			session.Destroy()
+			<-session.Done()
 
 			attrs, err := remote.GetMany(ctx, ns, "a", "b")
 			Expect(err).NotTo(HaveOccurred())
@@ -221,6 +225,7 @@ var _ = Describe("revision (functional)", func() {
 
 		It("returns an empty attribute table when called without keys", func() {
 			session.Destroy() // even if the session has been destroyed
+			<-session.Done()
 
 			attrs, err := remote.GetMany(ctx, ns)
 			Expect(err).NotTo(HaveOccurred())
@@ -277,6 +282,7 @@ var _ = Describe("revision (functional)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			session.Destroy()
+			<-session.Done()
 
 			_, err = remote.GetMany(ctx, ns, "a")
 			Expect(err).To(HaveOccurred())
@@ -297,6 +303,7 @@ var _ = Describe("revision (functional)", func() {
 
 		It("returns a not found error if the session has been destroyed", func() {
 			session.Destroy()
+			<-session.Done()
 
 			var err error
 			remote, err = remote.Update(ctx, ns, rinq.Set("a", "1"))
@@ -359,6 +366,7 @@ var _ = Describe("revision (functional)", func() {
 
 		It("returns a not found error if the session has been destroyed", func() {
 			session.Destroy()
+			<-session.Done()
 
 			var err error
 			remote, err = remote.Clear(ctx, ns)
@@ -380,6 +388,7 @@ var _ = Describe("revision (functional)", func() {
 
 		It("returns a not found error if the session has been destroyed", func() {
 			session.Destroy()
+			<-session.Done()
 
 			err := remote.Destroy(ctx)
 			Expect(err).To(HaveOccurred())

--- a/src/rinq/session.go
+++ b/src/rinq/session.go
@@ -154,11 +154,14 @@ type Session interface {
 	// returned immediately.
 	Unlisten(ns string) error
 
-	// Destroy terminates the session after any pending Session.Call()
-	// operations complete.
+	// Destroy terminates the session.
+	//
+	// Destroy does NOT block until the session is destroyed, use the
+	// Session.Done() channel to wait for the session to be destroyed.
 	Destroy()
 
-	// Done returns a channel that is closed when the session is destroyed.
+	// Done returns a channel that is closed when the session is destroyed and
+	// any pending Session.Call() operations have completed.
 	//
 	// The session may be destroyed directly with Destroy(), or via a Revision
 	// that refers to this session, either locally or remotely.

--- a/src/rinqamqp/peer.go
+++ b/src/rinqamqp/peer.go
@@ -214,6 +214,7 @@ func (p *peer) finalize(err error) error {
 
 	p.localStore.Each(func(sess rinq.Session, _ *localsession.State) {
 		sess.Destroy()
+		<-sess.Done()
 	})
 
 	<-service.WaitAll(


### PR DESCRIPTION
This PR alters `Session.Destroy()` so that it no longer blocks until pending `Call()` operations are complete. This behavior more closely matches other entities in Rinq, such as `Peer.GracefulStop()`.

The `Session.Done()` channel can still be used to wait for pending calls.

Internally, this also means that a session's destroyed state is exclusively driven by `localsession.state.Destroyed()`.