### PR TITLE
Remove `tip` version from build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: go
 services:
 - rabbitmq
-go:
-- '1.9'
-- tip
-matrix:
-  fast_finish: true
-  allow_failures:
-  - go: tip
+go: '1.9'
 script: make ci -j 8
 after_script: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Fixes #157.