### PR TITLE
Use Escape() for all attribute string representations.

### DIFF
--- a/src/rinq/attr.go
+++ b/src/rinq/attr.go
@@ -1,6 +1,9 @@
 package rinq
 
-import "github.com/rinq/rinq-go/src/internal/x/bufferpool"
+import (
+	"github.com/rinq/rinq-go/src/internal/x/bufferpool"
+	"github.com/rinq/rinq-go/src/internal/x/repr"
+)
 
 // Attr is a sesssion attribute.
 //
@@ -43,15 +46,15 @@ func (attr Attr) String() string {
 		} else {
 			buf.WriteString("-")
 		}
-		buf.WriteString(attr.Key)
+		buf.WriteString(repr.Escape(attr.Key))
 	} else {
-		buf.WriteString(attr.Key)
+		buf.WriteString(repr.Escape(attr.Key))
 		if attr.IsFrozen {
 			buf.WriteString("@")
 		} else {
 			buf.WriteString("=")
 		}
-		buf.WriteString(attr.Value)
+		buf.WriteString(repr.Escape(attr.Value))
 	}
 
 	return buf.String()

--- a/src/rinq/attr_test.go
+++ b/src/rinq/attr_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Attr", func() {
 
 		It("escapes attributes that contain certain characters", func() {
 			attr := rinq.Attr{Key: "foo key", Value: "bar value"}
-			Expect(attr.String()).To(Equal("\"foo key\"=\"bar value\""))
+			Expect(attr.String()).To(Equal(`"foo key"="bar value"`))
 		})
 	})
 })

--- a/src/rinq/attr_test.go
+++ b/src/rinq/attr_test.go
@@ -27,6 +27,11 @@ var _ = Describe("Attr", func() {
 			attr := rinq.Attr{Key: "foo", Value: "", IsFrozen: true}
 			Expect(attr.String()).To(Equal("!foo"))
 		})
+
+		It("escapes attributes that contain certain characters", func() {
+			attr := rinq.Attr{Key: "foo key", Value: "bar value"}
+			Expect(attr.String()).To(Equal("\"foo key\"=\"bar value\""))
+		})
 	})
 })
 


### PR DESCRIPTION
Fixes #151 

The only other `WriteString()` calls that I didn't add the escape to were the ones writing a namespace, specific symbol(s) or the unexported `join` method writing a separator.
