### PR TITLE
Promote "trace ID" to a first-class component of the low level APIs.

### DIFF
--- a/src/internal/command/invoker.go
+++ b/src/internal/command/invoker.go
@@ -21,31 +21,34 @@ type Invoker interface {
 	CallUnicast(
 		ctx context.Context,
 		msgID ident.MessageID,
+		traceID string,
 		target ident.PeerID,
 		namespace string,
 		command string,
 		payload *rinq.Payload,
-	) (string, *rinq.Payload, error)
+	) (*rinq.Payload, error)
 
 	// CallBalanced sends a load-balanced command request to the first available
 	// peer and blocks until a response is received or the context deadline is met.
 	CallBalanced(
 		ctx context.Context,
 		msgID ident.MessageID,
+		traceID string,
 		namespace string,
 		command string,
 		payload *rinq.Payload,
-	) (string, *rinq.Payload, error)
+	) (*rinq.Payload, error)
 
 	// CallBalancedAsync sends a load-balanced command request to the first
 	// available peer, instructs it to send a response, but does not block.
 	CallBalancedAsync(
 		ctx context.Context,
 		msgID ident.MessageID,
+		traceID string,
 		namespace string,
 		command string,
 		payload *rinq.Payload,
-	) (string, error)
+	) error
 
 	// SetAsyncHandler sets the asynchronous handler to use for a specific
 	// session.
@@ -56,18 +59,20 @@ type Invoker interface {
 	ExecuteBalanced(
 		ctx context.Context,
 		msgID ident.MessageID,
+		traceID string,
 		namespace string,
 		command string,
 		payload *rinq.Payload,
-	) (string, error)
+	) error
 
 	// ExecuteMulticast sends a multicast command request to the all available
 	// peers and returns immediately.
 	ExecuteMulticast(
 		ctx context.Context,
 		msgID ident.MessageID,
+		traceID string,
 		namespace string,
 		command string,
 		payload *rinq.Payload,
-	) (string, error)
+	) error
 }

--- a/src/internal/localsession/session_state.go
+++ b/src/internal/localsession/session_state.go
@@ -1,11 +1,13 @@
 package localsession
 
 import (
+	"context"
 	"errors"
 
 	"github.com/rinq/rinq-go/src/internal/attributes"
 	"github.com/rinq/rinq-go/src/rinq"
 	"github.com/rinq/rinq-go/src/rinq/ident"
+	"github.com/rinq/rinq-go/src/rinq/trace"
 )
 
 // This file contains methods of the Session struct that are not defined in
@@ -192,8 +194,18 @@ func (s *Session) destroy() {
 }
 
 // nextMessageID returns a new unique message ID generated from the current
-// session-ref, and the attributes as they existed at that ref.
-func (s *Session) nextMessageID() ident.MessageID {
+// session-ref.
+//
+// If parent does not already have a trace ID, the message ID is used a the
+// trace ID.
+func (s *Session) nextMessageID(ctx context.Context) (msgID ident.MessageID, traceID string) {
 	s.msgSeq++
-	return s.ref.Message(s.msgSeq)
+	msgID = s.ref.Message(s.msgSeq)
+	traceID = trace.Get(ctx)
+
+	if traceID == "" {
+		traceID = msgID.String()
+	}
+
+	return
 }

--- a/src/internal/notify/notifier.go
+++ b/src/internal/notify/notifier.go
@@ -14,19 +14,21 @@ type Notifier interface {
 	NotifyUnicast(
 		ctx context.Context,
 		msgID ident.MessageID,
+		traceID string,
 		s ident.SessionID,
 		ns string,
 		t string,
 		out *rinq.Payload,
-	) (string, error)
+	) error
 
 	// NotifyMulticast sends a notification to all sessions matching a constraint.
 	NotifyMulticast(
 		ctx context.Context,
 		msgID ident.MessageID,
+		traceID string,
 		con constraint.Constraint,
 		ns string,
 		t string,
 		out *rinq.Payload,
-	) (string, error)
+	) error
 }

--- a/src/rinq/trace/context.go
+++ b/src/rinq/trace/context.go
@@ -23,14 +23,20 @@ func With(parent context.Context, t string) context.Context {
 }
 
 // WithRoot returns a new context derived from parent that includes an
-// application-defined "trace ID" value, only if the context does not already
-// contain such a trace ID. Otherwise; it returns parent.
-func WithRoot(parent context.Context, t string) (context.Context, bool) {
-	if parent.Value(key) == nil {
-		return With(parent, t), true
+// application-defined "trace ID" value, only if the parent does not already
+// contain such a trace ID.
+//
+// If parent already contains a trace ID, ctx is parent, id is the trace ID from
+// parent and ok is false. Otherwise, ctx is the derived context containing  t
+// as the trace ID, id is t and ok is true.
+func WithRoot(parent context.Context, t string) (ctx context.Context, id string, ok bool) {
+	existing := parent.Value(key)
+
+	if existing == nil {
+		return With(parent, t), t, true
 	}
 
-	return parent, false
+	return parent, existing.(string), false
 }
 
 // Get returns the trace identifier from ctx, or an empty string if none is

--- a/src/rinq/trace/context_test.go
+++ b/src/rinq/trace/context_test.go
@@ -25,17 +25,19 @@ var _ = Describe("With", func() {
 
 var _ = Describe("WithRoot", func() {
 	It("adds the trace ID", func() {
-		ctx, added := WithRoot(context.Background(), "<id>")
+		ctx, id, added := WithRoot(context.Background(), "<id>")
 
 		Expect(Get(ctx)).To(Equal("<id>"))
+		Expect(id).To(Equal("<id>"))
 		Expect(added).To(BeTrue())
 	})
 
 	It("returns the parent context unchanged", func() {
 		parent := With(context.Background(), "<id 1>")
-		ctx, added := WithRoot(parent, "<id 2>")
+		ctx, id, added := WithRoot(parent, "<id 2>")
 
 		Expect(ctx).To(BeIdenticalTo(parent))
+		Expect(id).To(Equal("<id 1>"))
 		Expect(added).To(BeFalse())
 	})
 })

--- a/src/rinqamqp/internal/amqputil/trace.go
+++ b/src/rinqamqp/internal/amqputil/trace.go
@@ -7,23 +7,16 @@ import (
 	"github.com/streadway/amqp"
 )
 
-// PackTrace sets msg.CorrelationId to the trace ID in ctx, and returns the ID.
-//
-// If ctx does not have a trace ID, the return value is msg.MessageId.
+// PackTrace sets msg.CorrelationId to traceID, only if it differs to msgID.
 //
 // The AMQP correlation ID field is used to tie "root" requests (be they command
 // requests or notifications) to any requests that are made in response to that
 // "root" request. This is different to the popular use of the correlation ID
 // field, which is often used to relate a response to a request.
-func PackTrace(ctx context.Context, msg *amqp.Publishing) string {
-	traceID := trace.Get(ctx)
-
-	if traceID == "" || traceID == msg.MessageId {
-		return msg.MessageId
+func PackTrace(msg *amqp.Publishing, traceID string) {
+	if traceID != msg.MessageId {
+		msg.CorrelationId = traceID
 	}
-
-	msg.CorrelationId = traceID
-	return traceID
 }
 
 // UnpackTrace creates a new context with a trace ID based on the AMQP correlation

--- a/src/rinqamqp/internal/amqputil/trace_test.go
+++ b/src/rinqamqp/internal/amqputil/trace_test.go
@@ -5,32 +5,44 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/rinq/rinq-go/src/rinq/trace"
 	"github.com/rinq/rinq-go/src/rinqamqp/internal/amqputil"
 	"github.com/streadway/amqp"
 )
 
 var _ = Describe("Trace", func() {
-	Describe("PackTrace and UnpackTrace", func() {
+	Describe("PackTrace", func() {
 		It("sets the correlation ID", func() {
-			del := amqp.Delivery{MessageId: "<id>"}
-			ctx := amqputil.UnpackTrace(context.Background(), &del)
+			pub := amqp.Publishing{MessageId: "<id>"}
+			amqputil.PackTrace(&pub, "<trace>")
 
-			pub := amqp.Publishing{}
-			result := amqputil.PackTrace(ctx, &pub)
-
-			Expect(pub.CorrelationId).To(Equal(del.MessageId))
-			Expect(result).To(Equal(del.MessageId))
+			Expect(pub.CorrelationId).To(Equal("<trace>"))
 		})
 
-		It("does not set the correlation ID if it's the same as the message ID", func() {
+		It("does not set the correlation ID if the trace ID the same as the message ID", func() {
+			pub := amqp.Publishing{MessageId: "<id>"}
+			amqputil.PackTrace(&pub, "<id>")
+
+			Expect(pub.CorrelationId).To(Equal(""))
+		})
+	})
+
+	Describe("UnpackTrace", func() {
+		It("returns a context with the trace ID based on the message ID", func() {
 			del := amqp.Delivery{MessageId: "<id>"}
 			ctx := amqputil.UnpackTrace(context.Background(), &del)
 
-			pub := amqp.Publishing{MessageId: "<id>"}
-			result := amqputil.PackTrace(ctx, &pub)
+			Expect(trace.Get(ctx)).To(Equal("<id>"))
+		})
 
-			Expect(pub.CorrelationId).To(Equal(""))
-			Expect(result).To(Equal(del.MessageId))
+		It("returns a context with the trace ID based on the correlation ID", func() {
+			del := amqp.Delivery{
+				MessageId:     "<id>",
+				CorrelationId: "<trace>",
+			}
+			ctx := amqputil.UnpackTrace(context.Background(), &del)
+
+			Expect(trace.Get(ctx)).To(Equal("<trace>"))
 		})
 	})
 })

--- a/src/rinqamqp/internal/commandamqp/invoker.go
+++ b/src/rinqamqp/internal/commandamqp/invoker.go
@@ -96,44 +96,44 @@ func newInvoker(
 func (i *invoker) CallUnicast(
 	ctx context.Context,
 	msgID ident.MessageID,
+	traceID string,
 	target ident.PeerID,
 	ns string,
 	cmd string,
 	out *rinq.Payload,
-) (string, *rinq.Payload, error) {
+) (*rinq.Payload, error) {
 	msg := &amqp.Publishing{
 		MessageId: msgID.String(),
 		Priority:  callUnicastPriority,
 	}
-	packRequest(msg, ns, cmd, out, replyCorrelated)
-	traceID := amqputil.PackTrace(ctx, msg)
+	packRequest(msg, traceID, ns, cmd, out, replyCorrelated)
 
 	logUnicastCallBegin(i.logger, i.peerID, msgID, target, ns, cmd, traceID, out)
 	in, err := i.call(ctx, unicastExchange, target.String(), msg)
 	logCallEnd(i.logger, i.peerID, msgID, ns, cmd, traceID, in, err)
 
-	return traceID, in, err
+	return in, err
 }
 
 func (i *invoker) CallBalanced(
 	ctx context.Context,
 	msgID ident.MessageID,
+	traceID string,
 	ns string,
 	cmd string,
 	out *rinq.Payload,
-) (string, *rinq.Payload, error) {
+) (*rinq.Payload, error) {
 	msg := &amqp.Publishing{
 		MessageId: msgID.String(),
 		Priority:  callBalancedPriority,
 	}
-	packRequest(msg, ns, cmd, out, replyCorrelated)
-	traceID := amqputil.PackTrace(ctx, msg)
+	packRequest(msg, traceID, ns, cmd, out, replyCorrelated)
 
 	logBalancedCallBegin(i.logger, i.peerID, msgID, ns, cmd, traceID, out)
 	in, err := i.call(ctx, balancedExchange, ns, msg)
 	logCallEnd(i.logger, i.peerID, msgID, ns, cmd, traceID, in, err)
 
-	return traceID, in, err
+	return in, err
 }
 
 // CallBalancedAsync sends a load-balanced command request to the first
@@ -141,21 +141,21 @@ func (i *invoker) CallBalanced(
 func (i *invoker) CallBalancedAsync(
 	ctx context.Context,
 	msgID ident.MessageID,
+	traceID string,
 	ns string,
 	cmd string,
 	out *rinq.Payload,
-) (string, error) {
+) error {
 	msg := &amqp.Publishing{
 		MessageId: msgID.String(),
 		Priority:  callBalancedPriority,
 	}
-	packRequest(msg, ns, cmd, out, replyUncorrelated)
-	traceID := amqputil.PackTrace(ctx, msg)
+	packRequest(msg, traceID, ns, cmd, out, replyUncorrelated)
 
 	err := i.send(ctx, balancedExchange, ns, msg)
 	logAsyncRequest(i.logger, i.peerID, msgID, ns, cmd, traceID, out, err)
 
-	return traceID, err
+	return err
 }
 
 // SetAsyncHandler sets the asynchronous handler to use for a specific
@@ -174,42 +174,42 @@ func (i *invoker) SetAsyncHandler(sessID ident.SessionID, h rinq.AsyncHandler) {
 func (i *invoker) ExecuteBalanced(
 	ctx context.Context,
 	msgID ident.MessageID,
+	traceID string,
 	ns string,
 	cmd string,
 	out *rinq.Payload,
-) (string, error) {
+) error {
 	msg := &amqp.Publishing{
 		MessageId:    msgID.String(),
 		Priority:     executePriority,
 		DeliveryMode: amqp.Persistent,
 	}
-	packRequest(msg, ns, cmd, out, replyNone)
-	traceID := amqputil.PackTrace(ctx, msg)
+	packRequest(msg, traceID, ns, cmd, out, replyNone)
 
 	err := i.send(ctx, balancedExchange, ns, msg)
 	logBalancedExecute(i.logger, i.peerID, msgID, ns, cmd, traceID, out, err)
 
-	return traceID, err
+	return err
 }
 
 func (i *invoker) ExecuteMulticast(
 	ctx context.Context,
 	msgID ident.MessageID,
+	traceID string,
 	ns string,
 	cmd string,
 	out *rinq.Payload,
-) (string, error) {
+) error {
 	msg := &amqp.Publishing{
 		MessageId: msgID.String(),
 		Priority:  executePriority,
 	}
-	packRequest(msg, ns, cmd, out, replyNone)
-	traceID := amqputil.PackTrace(ctx, msg)
+	packRequest(msg, traceID, ns, cmd, out, replyNone)
 
 	err := i.send(ctx, multicastExchange, ns, msg)
 	logMulticastExecute(i.logger, i.peerID, msgID, ns, cmd, traceID, out, err)
 
-	return traceID, err
+	return err
 }
 
 // initialize prepares the AMQP channel and starts the state machine

--- a/src/rinqamqp/internal/commandamqp/message.go
+++ b/src/rinqamqp/internal/commandamqp/message.go
@@ -94,6 +94,7 @@ func unpackReplyMode(msg *amqp.Delivery) replyMode {
 
 func packRequest(
 	msg *amqp.Publishing,
+	traceID string,
 	ns string,
 	cmd string,
 	p *rinq.Payload,
@@ -101,6 +102,7 @@ func packRequest(
 ) {
 	packNamespaceAndCommand(msg, ns, cmd)
 	packReplyMode(msg, m)
+	amqputil.PackTrace(msg, traceID)
 	msg.Body = p.Bytes()
 }
 

--- a/src/rinqamqp/internal/commandamqp/response.go
+++ b/src/rinqamqp/internal/commandamqp/response.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/rinq/rinq-go/src/rinq"
+	"github.com/rinq/rinq-go/src/rinq/trace"
 	"github.com/rinq/rinq-go/src/rinqamqp/internal/amqputil"
 	"github.com/streadway/amqp"
 )
@@ -148,7 +149,8 @@ func (r *response) respond(msg *amqp.Publishing) {
 	}
 	defer r.channels.Put(channel)
 
-	amqputil.PackTrace(r.context, msg)
+	// TODO: is this necessary for correlated responses?
+	amqputil.PackTrace(msg, trace.Get(r.context))
 
 	if r.replyMode == replyUncorrelated {
 		packNamespaceAndCommand(msg, r.request.Namespace, r.request.Command)

--- a/src/rinqamqp/internal/notifyamqp/message.go
+++ b/src/rinqamqp/internal/notifyamqp/message.go
@@ -32,6 +32,7 @@ func unicastRoutingKey(ns string, p ident.PeerID) string {
 
 func packCommonAttributes(
 	msg *amqp.Publishing,
+	traceID string,
 	ns string,
 	t string,
 	p *rinq.Payload,
@@ -44,6 +45,8 @@ func packCommonAttributes(
 	}
 
 	msg.Headers[namespaceHeader] = ns
+
+	amqputil.PackTrace(msg, traceID)
 }
 
 func unpackCommonAttributes(msg *amqp.Delivery) (ns, t string, p *rinq.Payload, err error) {

--- a/src/rinqamqp/internal/notifyamqp/notifier.go
+++ b/src/rinqamqp/internal/notifyamqp/notifier.go
@@ -44,18 +44,18 @@ func newNotifier(
 func (n *notifier) NotifyUnicast(
 	ctx context.Context,
 	msgID ident.MessageID,
+	traceID string,
 	target ident.SessionID,
 	ns string,
 	notificationType string,
 	payload *rinq.Payload,
-) (traceID string, err error) {
+) (err error) {
 	msg := amqp.Publishing{
 		MessageId: msgID.String(),
 	}
 
-	packCommonAttributes(&msg, ns, notificationType, payload)
+	packCommonAttributes(&msg, traceID, ns, notificationType, payload)
 	packTarget(&msg, target)
-	traceID = amqputil.PackTrace(ctx, &msg)
 
 	err = amqputil.PackSpanContext(ctx, &msg)
 
@@ -69,18 +69,18 @@ func (n *notifier) NotifyUnicast(
 func (n *notifier) NotifyMulticast(
 	ctx context.Context,
 	msgID ident.MessageID,
+	traceID string,
 	con constraint.Constraint,
 	ns string,
 	notificationType string,
 	payload *rinq.Payload,
-) (traceID string, err error) {
+) (err error) {
 	msg := amqp.Publishing{
 		MessageId: msgID.String(),
 	}
 
-	packCommonAttributes(&msg, ns, notificationType, payload)
+	packCommonAttributes(&msg, traceID, ns, notificationType, payload)
 	packConstraint(&msg, con)
-	traceID = amqputil.PackTrace(ctx, &msg)
 
 	err = amqputil.PackSpanContext(ctx, &msg)
 


### PR DESCRIPTION
The logic for producing the trace ID was previously embedded in the AMQP implementation, which was not appropriate as it's not a transport-specific concern.

This also means the `Session` facade et al can determine the trace ID on their own, and hence log it before making the call to the lower-level API.